### PR TITLE
feat: add support contact endpoint

### DIFF
--- a/src/main/kotlin/com/qlarr/backend/api/support/ContactRequest.kt
+++ b/src/main/kotlin/com/qlarr/backend/api/support/ContactRequest.kt
@@ -1,0 +1,7 @@
+package com.qlarr.backend.api.support
+
+data class ContactRequest(
+    val name: String,
+    val email: String,
+    val message: String
+)

--- a/src/main/kotlin/com/qlarr/backend/controllers/SupportController.kt
+++ b/src/main/kotlin/com/qlarr/backend/controllers/SupportController.kt
@@ -1,0 +1,21 @@
+package com.qlarr.backend.controllers
+
+import com.qlarr.backend.api.support.ContactRequest
+import com.qlarr.backend.services.SupportService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class SupportController(
+    private val supportService: SupportService
+) {
+
+    @PostMapping("/support/contact")
+    fun contact(@RequestBody contactRequest: ContactRequest): ResponseEntity<Any> {
+        supportService.submitContactForm(contactRequest)
+        return ResponseEntity(HttpStatus.OK)
+    }
+}

--- a/src/main/kotlin/com/qlarr/backend/security/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/qlarr/backend/security/SecurityConfiguration.kt
@@ -51,6 +51,7 @@ class SecurityConfiguration(
                 .requestMatchers(POST, "/user/forgot_password").permitAll()
                 .requestMatchers(POST, "/user/reset_password").permitAll()
                 .requestMatchers(POST, "/user/refresh_token").permitAll()
+                .requestMatchers(POST, "/support/contact").permitAll()
         }
         http.authorizeHttpRequests()
             .anyRequest()

--- a/src/main/kotlin/com/qlarr/backend/services/SupportService.kt
+++ b/src/main/kotlin/com/qlarr/backend/services/SupportService.kt
@@ -1,0 +1,37 @@
+package com.qlarr.backend.services
+
+import com.qlarr.backend.api.support.ContactRequest
+import com.qlarr.backend.common.isValidEmail
+import com.qlarr.backend.exceptions.InvalidInputException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+@Service
+class SupportService(
+    private val emailService: EmailService,
+    @Value("\${support.email}") private val supportEmail: String
+) {
+
+    fun submitContactForm(contactRequest: ContactRequest) {
+        if (contactRequest.name.isBlank()) {
+            throw InvalidInputException("Name is required")
+        }
+        if (contactRequest.email.isBlank() || !contactRequest.email.isValidEmail()) {
+            throw InvalidInputException("Valid email is required")
+        }
+        if (contactRequest.message.isBlank()) {
+            throw InvalidInputException("Message is required")
+        }
+
+        val subject = "Contact Form: ${contactRequest.name}"
+        val body = """
+            <h3>New Contact Form Submission</h3>
+            <p><strong>Name:</strong> ${contactRequest.name}</p>
+            <p><strong>Email:</strong> ${contactRequest.email}</p>
+            <p><strong>Message:</strong></p>
+            <p>${contactRequest.message}</p>
+        """.trimIndent()
+
+        emailService.sendEmail(to = supportEmail, subject = subject, body = body)
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,6 +36,8 @@ mail:
   password: ${MAIL_PASSWORD}
   username: ${MAIL_USERNAME}
 frontendUrl: ${FRONTEND_URL}
+support:
+  email: ${SUPPORT_EMAIL}
 fileSystem:
   rootFolder: ${FILE_SYSTEM_ROOT_FOLDER}
 ---
@@ -59,3 +61,5 @@ fileSystem:
 jwt:
   secret: lGYGGQSGHvq1lIw6Y3Ipy06H8SpSgHcARdPztZAS7Ug=
 frontendUrl: http://localhost:3000
+support:
+  email: support@localhost

--- a/src/test/kotlin/com/qlarr/backend/services/SupportServiceTest.kt
+++ b/src/test/kotlin/com/qlarr/backend/services/SupportServiceTest.kt
@@ -1,0 +1,77 @@
+package com.qlarr.backend.services
+
+import com.qlarr.backend.api.support.ContactRequest
+import com.qlarr.backend.exceptions.InvalidInputException
+import io.mockk.*
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class SupportServiceTest {
+
+    private val emailService: EmailService = mockk()
+    private val supportEmail = "support@test.com"
+
+    private lateinit var supportService: SupportService
+
+    @BeforeEach
+    fun setup() {
+        supportService = SupportService(emailService, supportEmail)
+    }
+
+    @Test
+    fun `valid form sends email`() {
+        every { emailService.sendEmail(any(), any(), any()) } just Runs
+
+        supportService.submitContactForm(
+            ContactRequest(name = "John", email = "john@example.com", message = "Hello")
+        )
+
+        verify(exactly = 1) {
+            emailService.sendEmail(
+                to = supportEmail,
+                subject = any(),
+                body = any()
+            )
+        }
+    }
+
+    @Test
+    fun `blank name throws InvalidInputException`() {
+        assertThrows<InvalidInputException> {
+            supportService.submitContactForm(
+                ContactRequest(name = "", email = "john@example.com", message = "Hello")
+            )
+        }
+    }
+
+    @Test
+    fun `blank email throws InvalidInputException`() {
+        assertThrows<InvalidInputException> {
+            supportService.submitContactForm(
+                ContactRequest(name = "John", email = "", message = "Hello")
+            )
+        }
+    }
+
+    @Test
+    fun `invalid email throws InvalidInputException`() {
+        assertThrows<InvalidInputException> {
+            supportService.submitContactForm(
+                ContactRequest(name = "John", email = "not-an-email", message = "Hello")
+            )
+        }
+    }
+
+    @Test
+    fun `blank message throws InvalidInputException`() {
+        assertThrows<InvalidInputException> {
+            supportService.submitContactForm(
+                ContactRequest(name = "John", email = "john@example.com", message = "")
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `POST /support/contact` public endpoint for the support bubble contact form
- New `SupportController`, `SupportService`, and `ContactRequest` data class
- Validates name, email, and message fields, then sends email to configured `SUPPORT_EMAIL`
- Permit endpoint in `SecurityConfiguration` (no auth required)
- Add `support.email` config in `application.yaml`
- Unit tests for validation and email sending

## Related
- Frontend PR: https://github.com/qlarr-surveys/frontend/pull/155