### PR TITLE
feat: add GET endpoint for autocomplete values and fix duplicate key bug

### DIFF
--- a/src/main/kotlin/com/qlarr/backend/controllers/AutoCompleteController.kt
+++ b/src/main/kotlin/com/qlarr/backend/controllers/AutoCompleteController.kt
@@ -27,6 +27,16 @@ class AutoCompleteController(
         return resourceService.uploadAutoCompleteResource(surveyId,componentId, file)
     }
 
+    @GetMapping("/autocomplete/{surveyId}/{componentId}")
+    @PreAuthorize("hasAnyAuthority({'super_admin','survey_admin'})")
+    fun getAutoCompleteValues(
+        @PathVariable surveyId: UUID,
+        @PathVariable componentId: String
+    ): ResponseEntity<List<String>> {
+        val values = resourceService.getAutoCompleteValues(surveyId, componentId)
+        return ResponseEntity.ok(values)
+    }
+
     @GetMapping("/survey/{surveyId}/autocomplete/{filename}")
     fun searchAutoComplete(
         @PathVariable surveyId: UUID,

--- a/src/main/kotlin/com/qlarr/backend/services/SurveyResourceService.kt
+++ b/src/main/kotlin/com/qlarr/backend/services/SurveyResourceService.kt
@@ -25,6 +25,7 @@ import org.springframework.http.HttpHeaders.CONTENT_LENGTH
 import org.springframework.http.HttpHeaders.CONTENT_TYPE
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import java.io.File
 import java.io.IOException
@@ -90,6 +91,7 @@ class SurveyResourceService(
         }
     }
 
+    @Transactional
     fun uploadAutoCompleteResource(
         surveyId: UUID,
         componentId: String,
@@ -113,15 +115,16 @@ class SurveyResourceService(
 
         existingEntity?.let {
             runCatching { helper.delete(surveyId, SurveyFolder.Resources, it.filename) }
+            autoCompleteRepository.delete(it)
+            autoCompleteRepository.flush()
         }
 
-        val entity = existingEntity?.copy(values = arrayNode, filename = savedFilename)
-            ?: AutoCompleteEntity(
-                surveyId = surveyId,
-                filename = savedFilename,
-                componentId = componentId,
-                values = arrayNode
-            )
+        val entity = AutoCompleteEntity(
+            surveyId = surveyId,
+            filename = savedFilename,
+            componentId = componentId,
+            values = arrayNode
+        )
 
         autoCompleteRepository.save(entity)
 
@@ -159,6 +162,13 @@ class SurveyResourceService(
         } catch (e: ResourceNotFoundException) {
             throw ResourceNotFoundException()
         }
+    }
+
+    fun getAutoCompleteValues(surveyId: UUID, componentId: String): List<String> {
+        surveyRepository.findByIdOrNull(surveyId) ?: throw SurveyNotFoundException()
+        val entity = autoCompleteRepository.findBySurveyIdAndComponentId(surveyId, componentId)
+            ?: return emptyList()
+        return entity.values.map { it.asText() }
     }
 
     fun search(


### PR DESCRIPTION
## Summary
- Add a new `GET /autocomplete/{surveyId}/{componentId}` endpoint to retrieve autocomplete values for a given survey component
- Fix duplicate key bug when re-uploading autocomplete resources by deleting the existing entity before inserting a new one (with `@Transactional` and `flush()`)

## Test plan
- [ ] Verify `GET /autocomplete/{surveyId}/{componentId}` returns the correct list of autocomplete values
- [ ] Verify uploading a new autocomplete file for an existing component replaces the old entry without duplicate key errors
- [ ] Verify authorization: only `super_admin` and `survey_admin` can access the new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)