### PR TITLE
feat: include preview response count in analytics endpoint

### DIFF
--- a/src/main/kotlin/com/qlarr/backend/api/response/AnalyticsDto.kt
+++ b/src/main/kotlin/com/qlarr/backend/api/response/AnalyticsDto.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 data class AnalyticsDto(
     val totalResponses: Int,
     val incompleteResponses: Int,
+    val previewResponses: Int,
     val questions: List<AnalyticsQuestion>
 )
 

--- a/src/main/kotlin/com/qlarr/backend/persistence/entities/SurveyEntity.kt
+++ b/src/main/kotlin/com/qlarr/backend/persistence/entities/SurveyEntity.kt
@@ -92,6 +92,7 @@ interface ResponseCount {
 interface AnalyticsResponseCount {
     val completedCount: Int
     val incompleteCount: Int
+    val previewCount: Int
 }
 
 data class SurveyNavigationData(

--- a/src/main/kotlin/com/qlarr/backend/persistence/repositories/ResponseRepository.kt
+++ b/src/main/kotlin/com/qlarr/backend/persistence/repositories/ResponseRepository.kt
@@ -35,7 +35,8 @@ interface ResponseRepository : JpaRepository<SurveyResponseEntity, UUID> {
     @Query(
         "SELECT " +
                 "COUNT(CASE WHEN submit_date IS NOT NULL AND preview = false THEN 1 END) as completedCount, " +
-                "COUNT(CASE WHEN submit_date IS NULL AND preview = false THEN 1 END) as incompleteCount " +
+                "COUNT(CASE WHEN submit_date IS NULL AND preview = false THEN 1 END) as incompleteCount, " +
+                "COUNT(CASE WHEN preview = true THEN 1 END) as previewCount " +
                 "FROM responses WHERE survey_id = :surveyId", nativeQuery = true
     )
     fun analyticsResponseCounts(surveyId: UUID): AnalyticsResponseCount

--- a/src/main/kotlin/com/qlarr/backend/services/AnalyticsService.kt
+++ b/src/main/kotlin/com/qlarr/backend/services/AnalyticsService.kt
@@ -98,6 +98,7 @@ class AnalyticsService(
         return AnalyticsDto(
             totalResponses = counts.completedCount + counts.incompleteCount,
             incompleteResponses = counts.incompleteCount,
+            previewResponses = counts.previewCount,
             questions = questions
         )
     }


### PR DESCRIPTION
## Summary
- Add `previewCount` to the `analyticsResponseCounts()` SQL query and `AnalyticsResponseCount` projection interface
- Add `previewResponses` field to `AnalyticsDto`
- Wire the count through `AnalyticsService.getAnalytics()`

The frontend already handles `previewResponses` (defaulting to `0`), so this backend change is all that's needed to show preview counts in analytics charts.