### PR TITLE
bug_report.yml: fix `placeholder` cannot be empty template error

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,7 +49,7 @@ body:
     attributes:
       label: Actual HTTP status
       description: e.g., 500, 400
-      placeholder: ''
+      placeholder: '503'
   - type: textarea
     id: request
     attributes:


### PR DESCRIPTION
<!-- markdownlint-disable line-length -->
# Description

it fixes the bug report issue template. template schema didn't enforce non-empty placeholder fields, but the GitHub UI is reporting "`placeholder` must be of type String and cannot be empty" errors on it.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Database migration
- [ ] Documentation update

## How to Test

1. Build the project:

   ```bash
   ./gradlew build
   ```

2. Start PostgreSQL (required):

   ```bash
   docker-compose up -d postgres-db
   ```

3. Run the application:

   ```bash
   ./gradlew bootRun
   ```

4. Test your changes:
   - [ ] Describe how to verify the fix works

## Testing

- [ ] Unit tests pass (`./gradlew test`)
- [ ] Integration tests pass
- [ ] E2E tests pass (if applicable)
- [ ] Manual API testing completed

## Checklist

- [ ] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [ ] Code follows layered architecture (Controllers → Services → Repositories)
- [ ] Database changes include Liquibase migration
- [x] No new security vulnerabilities
- [ ] Documentation updated (if API changes)

## Related Issue

Closes #

## Additional Notes

<!-- Any other context about the PR -->